### PR TITLE
Fix: 페이지네이션 오류 수정

### DIFF
--- a/src/components/myPage/Collections.jsx
+++ b/src/components/myPage/Collections.jsx
@@ -30,7 +30,7 @@ const Collections = () => {
 
   const [activePage, setActivePage] = useState(1);
   const offset = (activePage - 1) * PAGE_LIMIT;
-  const total = isSuccess && +(data.length / 5).toFixed();
+  const total = isSuccess && Math.ceil(data.length / 5);
   const collection = isSuccess && data?.slice(offset, offset + PAGE_LIMIT);
 
   return (


### PR DESCRIPTION
My page collection list에서 페이지네이션 오류 발견하여 수정했습니다.

- 오류: 토탈 페이지 계산식에서 반올림으로 계산하여 total 페이지 증가하지 않는 경우 발생
- 수정: 올림으로 계산하는 것으로 변경