### PR TITLE
Fix/마이페이지 통계 데이터 초기값 이슈 수정

### DIFF
--- a/src/components/myPage/Statistics/StatsByGenre.jsx
+++ b/src/components/myPage/Statistics/StatsByGenre.jsx
@@ -34,15 +34,23 @@ const StatsByGenre = () => {
   return (
     <>
       <Group position="apart" mt={7}>
-        <Text fz="lg" fw={700} align="left">
-          <Text fw={900} c={dark ? 'violet.2' : 'violet.9'} fz="inherit" span>
-            {top3Genres[0]?.label}{' '}
+        {top3Genres.length === 0 ? (
+          <Text fz="lg" fw={700} align="left">
+            무슨 장르를 좋아하시는지 분석해드려요
           </Text>
-          장르를 가장 많이 감상했어요.
-        </Text>
+        ) : (
+          <Text fz="lg" fw={700} align="left">
+            <Text fw={900} c={dark ? 'violet.2' : 'violet.9'} fz="inherit" span>
+              {top3Genres[0]?.label}{' '}
+            </Text>
+            장르를 가장 많이 감상했어요.
+          </Text>
+        )}
       </Group>
       <Text c="teal" fz="sm" fw={700} align="start">
-        많이 시청한 장르 TOP3는 {top3Genres.map(({ label }) => label).join(', ')} 입니다.
+        {top3Genres.length === 0
+          ? '지금부터 컨텐츠를 감상해보세요!'
+          : `많이 시청한 장르 TOP3는 ${top3Genres.map(({ label }) => label).join(', ')} 입니다.`}
       </Text>
       <Flex justify="center" align="center" gap={0}>
         <Group position="center">

--- a/src/components/myPage/Statistics/StatsByProvider.jsx
+++ b/src/components/myPage/Statistics/StatsByProvider.jsx
@@ -68,7 +68,7 @@ const StatsByProvider = () => {
         </Text>
       </Group>
       <Text c="teal" fz="sm" fw={700} align="start">
-        {maxProvider}를 가장 많이 사용했어요.
+        {total === 0 ? '지금부터 컨텐츠를 감상해보세요!' : `${maxProvider}를 가장 많이 사용했어요.`}
       </Text>
       <ProgressLabel sections={segments} size={34} mt="md" />
       <SimpleGrid cols={3} breakpoints={[{ maxWidth: '40rem', cols: 2 }]} mt="md">

--- a/src/hooks/statistics/useStatsByProvider.js
+++ b/src/hooks/statistics/useStatsByProvider.js
@@ -57,7 +57,7 @@ const getNewData = (providers, newTotal) => {
 
   const newData = defaultData.data
     .map(item => ({ ...item, count: getCountByProvider(item.id, providerIds) }))
-    .map(item => ({ ...item, part: +((item.count / newTotal) * 100).toFixed() }));
+    .map(item => ({ ...item, part: item.count === 0 ? 0 : +((item.count / newTotal) * 100).toFixed() }));
   return newData;
 };
 


### PR DESCRIPTION
마이페이지의 통계 데이터 초기값 이슈 수정하였습니다.

- history list 비어있을 경우,
  - 통계 그래프 상단의 초기 메시지 수정
  - 장르별 통계 그래프에서 장르별 % 데이터 NaN%으로 표기되는 부분 수정